### PR TITLE
Deprecate Pandas, Matplotlib, and Python 2 support

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,9 +9,9 @@ ipython = "*"
 flake8 = "*"
 autopep8 = "*"
 tox = "*"
+notebook = "*"
 
 [packages]
-matplotlib = "*"
 numpy = "*"
 six = "*"
 

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ tox = "*"
 [packages]
 matplotlib = "*"
 numpy = "*"
-pandas = "== 0.24.2"
 six = "*"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ notebook = "*"
 
 [packages]
 numpy = "*"
-six = "*"
 
 [requires]
 python_version = "3.6"

--- a/README.md
+++ b/README.md
@@ -7,15 +7,18 @@ Total Scattering Function Manipulator:
 | [![codecov](https://codecov.io/gh/neutrons/pystog/branch/master/graph/badge.svg)](https://codecov.io/gh/neutrons/pystog) | [![Anaconda-Server Badge](https://anaconda.org/neutrons/pystog/badges/version.svg)](https://anaconda.org/neutrons/pystog)| [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)  |
 |[![Documentation Status](https://readthedocs.org/projects/pystog/badge/?version=latest)](https://pystog.readthedocs.io/en/latest/?badge=latest) | [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active) |  |
 
-From total scattering functions, we have reciprocal-space structure factors and real-space pair distribution functions that are related via a Fourier transform. PyStoG is a package that allows for:
+From total scattering functions, we have reciprocal-space structure factors and real-space pair distribution functions that are related via a Fourier transform.
+PyStoG is a package that allows for:
 1. Converting between the various functions used by different "communities" (ie researchers who study crystalline versus amorphous or glass materials). Conversions are for either real-space or reciprocal-space.
 2. Perform the transform between the different available functions of choice
 3. Fourier filter to remove spurious artificats in the data (ie aphysical, sub-angstrom low-r peaks in G(r) from experiments)
 
-![alt text](https://raw.githubusercontent.com/marshallmcdonnell/mantid_total_scattering/master/images/sofq_to_gofr.png)
+![alt text](https://raw.githubusercontent.com/neutrons/pystog/master/images/sofq_to_gofr.png)
 
 
-The name **PyStoG** comes from the fact that this is a _Pythonized_ version of **StoG**, a ~30 year old Fortran program that is part of the [RMCProfile software suite](http://www.rmcprofile.org/Main_Page). **StoG** means **"S(Q) to G(r)"** for the fact that it takes recirpocal-space S(Q) patterns from files and transforms them into a single G(r) pattern. The original *StoG* program has been developed, in reverse chronological order, by:
+The name **PyStoG** comes from the fact that this is a _Pythonized_ version of **StoG**, a ~30 year old Fortran program that is part of the [RMCProfile software suite](http://www.rmcprofile.org/Main_Page).
+**StoG** means **"S(Q) to G(r)"** for the fact that it takes recirpocal-space S(Q) patterns from files and transforms them into a single G(r) pattern.
+The original *StoG* program has been developed, in reverse chronological order, by:
 
  * Matthew Tucker and Martin Dove (~2009)
  * Spencer Howells (~1989)
@@ -23,7 +26,9 @@ The name **PyStoG** comes from the fact that this is a _Pythonized_ version of *
  
  A current state of the **StoG** program is kept in the `fortran` directory of this package.
 
-This project was initially just a "sandbox" for taking the capabilities of **StoG** and migrating them over to the [Mantid Framework](https://github.com/mantidproject/mantid). Yet, with more and more use cases, **PyStoG** was further developed as the stand-alone project it is now. Yet, migration to the Mantid Framework is still a goal since it feeds into the [ADDIE project](https://github.com/neutrons/addie)
+This project was initially just a "sandbox" for taking the capabilities of **StoG** and migrating them over to the [Mantid Framework](https://github.com/mantidproject/mantid).
+Yet, with more and more use cases, **PyStoG** was further developed as the stand-alone project it is now.
+Yet, migration to the Mantid Framework is still a goal since it feeds into the [ADDIE project](https://github.com/neutrons/addie)
 
 ## Installation
 
@@ -45,7 +50,8 @@ source /path/to/ENV/bin/activate
 pip install pystog
 ```
 
-Also, [`direnv`](https://github.com/direnv/direnv) is a useful and recommended way to manage the virtual environment. You can simply use an `.envrc` file which contains:
+Also, [`direnv`](https://github.com/direnv/direnv) is a useful and recommended way to manage the virtual environment.
+You can simply use an `.envrc` file which contains:
 
 `layout python3`
 
@@ -64,19 +70,20 @@ from pystog import StoG
 ```
 ** WARNING: Testing of the CLI is still ongoing**
 
-Also, there is a beta-version of a python script in the package that can be run on JSON input files and operates similarly to the original **StoG** program, only with extra `matplotlib` visualization of the output. This is `python cli` and can be used as follows:
+Also, there is a beta-version of a python script in the package that can be run on JSON input files and operates similarly to the original **StoG** program.
+This is `python cli` and can be used as follows:
 
 ```bash
 pystog_cli --json <input json>
 ```
-An example JSON can be found [here](https://github.com/marshallmcdonnell/pystog/blob/master/data/examples/argon_pystog.json)
+An example JSON can be found [here](https://github.com/neutrons/pystog/blob/master/data/examples/argon_pystog.json)
 
 ### Documentation
 The official documentation is hosted on readthedocs.org: [https://pystog.readthedocs.io/en/latest/](https://pystog.readthedocs.io/en/latest/)
 
 Also, a useful example reference is the [PDFFourierTransform](http://docs.mantidproject.org/nightly/algorithms/PDFFourierTransform-v1.html) algorithm in the Mantid Framework that has similar yet limited capabilities.
 
-Finally, tutorials in the form of Jupyter Notebooks can be launched via Binder by clicking the badge here [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/marshallmcdonnell/pystog/master?filepath=tutorials) or at the top of the page.
+Finally, tutorials in the form of Jupyter Notebooks can be launched via Binder by clicking the badge here [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/neutrons/pystog/master?filepath=tutorials) or at the top of the page.
 
 ## Running the tests
 From the parent directory of the module, run:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,11 +16,9 @@ requirements:
   build:
     - matplotlib
     - numpy
-    - pandas
   run:
     - matplotlib
     - numpy
-    - pandas
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -14,10 +14,8 @@ build:
 
 requirements:
   build:
-    - matplotlib
     - numpy
   run:
-    - matplotlib
     - numpy
 
 test:

--- a/data/examples/argon_pystog.json
+++ b/data/examples/argon_pystog.json
@@ -42,7 +42,6 @@
     "<b_coh>^2" : 3.644,
     "<b_tot^2>" : 5.435,
     "LorchFlag" : false,
-    "PlotFlag" : true,
     "Outputs" : { "StemName" : "merged_argon" }
 }
     

--- a/data/examples/input.json
+++ b/data/examples/input.json
@@ -25,7 +25,6 @@
     "FourierFilter" : { "Cutoff" : 1.5 },
     "<b_coh>^2" : 5.0,
     "LorchFlag" : "True",
-    "PlotFlag" : "True",
     "Outputs" : { "StemName" : "merged" }
 }
     

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,15 +1,19 @@
 =====
 About
 =====
-From total scattering functions, we have reciprocal-space structure factors and real-space pair distribution functions that are related via a Fourier transform. PyStoG is a package that allows for:
+From total scattering functions, we have reciprocal-space structure factors and real-space pair distribution functions that are related via a Fourier transform.
+PyStoG is a package that allows for:
 
-1. Converting between the various functions used by different "communities" (ie researchers who study crystalline versus amorphous or glass materials). Conversions are for either real-space or reciprocal-space.
+1. Converting between the various functions used by different "communities" (ie researchers who study crystalline versus amorphous or glass materials).
+   Conversions are for either real-space or reciprocal-space.
 2. Perform the transform between the different available functions of choice
 3. Fourier filter to remove spurious artificats in the data (ie aphysical, sub-angstrom low-r peaks in G(r) from experiments)
 
 .. image:: ../../images/sofq_to_gofr.png
 
-The name **PyStoG** comes from the fact that this is a *Pythonized* version of **StoG**, a ~30 year old Fortran program that is part of the RMCProfile_ software suite. **StoG** means **"S(Q) to G(r)"** for the fact that it takes recirpocal-space S(Q) patterns from files and transforms them into a single G(r) pattern. The original *StoG* program has been developed, in reverse chronological order, by:
+The name **PyStoG** comes from the fact that this is a *Pythonized* version of **StoG**, a ~30 year old Fortran program that is part of the RMCProfile_ software suite.
+**StoG** means **"S(Q) to G(r)"** for the fact that it takes recirpocal-space S(Q) patterns from files and transforms them into a single G(r) pattern.
+The original *StoG* program has been developed, in reverse chronological order, by:
 
  * Matthew Tucker and Martin Dove (~2009)
  * Spencer Howells (~1989)
@@ -17,10 +21,14 @@ The name **PyStoG** comes from the fact that this is a *Pythonized* version of *
 
  A current state of the **StoG** program is kept in the `fortran` directory of this package.
 
-This project was initially just a "sandbox" for taking the capabilities of **StoG** and migrating them over to the Mantid_ Framework. With more and more use cases, **PyStoG** was further developed as the stand-alone project it is now. Yet, migration to the Mantid Framework is still a goal since it feeds into the ADDIE_ project.
+This project was initially just a "sandbox" for taking the capabilities of **StoG** and migrating them over to the Mantid_ Framework.
+With more and more use cases, **PyStoG** was further developed as the stand-alone project it is now.
+Yet, migration to the Mantid Framework is still a goal since it feeds into the ADDIE_ project.
 
 
-PyStoG is not a Python replica of StoG but has the same goal as StoG. Yet, has capabilites that surpass StoG such as multiple input/output real and reciprocal space functions, diagnostic plotting with matplotlib, and modules allowing for re-construction of the workflow for processing total scattering data.
+PyStoG is not a Python replica of StoG but has the same goal as StoG.
+Yet, has capabilites that surpass StoG such as multiple input/output real
+and reciprocal space functions and modules allowing for re-construction of the workflow for processing total scattering data.
 
 .. _RMCProfile: http://www.rmcprofile.org/Main_Page
 .. _Mantid: https://github.com/mantidproject/mantid

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -5,12 +5,10 @@ Installation
 Requirements
 ============
 
-* Python (2.7, 3.5, 3.6 are tested)
-* matplotlib_
+* Python (3.6, 3.7, 3.8, and 3.9 are tested)
 * numpy_
 
 
-.. _matplotlib: https://matplotlib.org/
 .. _numpy: http://www.numpy.org/
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -8,12 +8,10 @@ Requirements
 * Python (2.7, 3.5, 3.6 are tested)
 * matplotlib_
 * numpy_
-* pandas_
 
 
 .. _matplotlib: https://matplotlib.org/
 .. _numpy: http://www.numpy.org/
-.. _pandas: http://pandas.pydata.org/
 
 
 

--- a/pystog/cli.py
+++ b/pystog/cli.py
@@ -1,4 +1,13 @@
-from __future__ import (absolute_import, division, print_function)
+"""
+==============
+PyStoG CLI
+==============
+
+This module defines the PyStoG CLI function that performs the workflow of the
+original FORTRAN-based StoG CLI
+"""
+
+
 import json
 
 from pystog import StoG

--- a/pystog/cli.py
+++ b/pystog/cli.py
@@ -43,10 +43,10 @@ def pystog_cli(kwargs=None):
     # print stog.get_lowR_mean_square()
 
     # Set the S(Q) and g(r) if no Fourier Filter
-    r = stog.df_gr_master[stog.gr_title].values
-    q = stog.df_sq_master[stog.sq_title].values
-    sq = stog.df_sq_master[stog.sq_title].values
-    gr_out = stog.df_gr_master[stog.gr_title].values
+    r = stog.gr_master[stog.gr_title].values
+    q = stog.sq_master[stog.sq_title].values
+    sq = stog.sq_master[stog.sq_title].values
+    gr_out = stog.gr_master[stog.gr_title].values
 
     # Apply Fourier Filter
     if "FourierFilter" in kwargs:

--- a/pystog/cli.py
+++ b/pystog/cli.py
@@ -1,11 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
-import argparse
-import inspect
 import json
 
-from pystog import Converter, Transformer, StoG
+from pystog import StoG
 from pystog.io import get_cli_args, parse_cli_args
-from pystog.utils import get_data, create_domain, write_out
 
 
 def pystog_cli(kwargs=None):
@@ -25,19 +22,9 @@ def pystog_cli(kwargs=None):
     stog.merge_data()
     stog.write_out_merged_sq()
 
-    if "PlotFlag" in kwargs:
-        if kwargs["PlotFlag"]:
-            stog.plot_merged_sq()
-
     # Initial S(Q) -> g(r) transform
     stog.transform_merged()
     stog.write_out_merged_gr()
-
-    if "PlotFlag" in kwargs:
-        if kwargs["PlotFlag"]:
-            stog.plot_gr(
-                ylabel=stog.real_space_function,
-                title="Merged %s" % stog.real_space_function)
 
     # TODO: Add the lowR minimizer here
     # print stog.get_lowR_mean_square()
@@ -59,136 +46,3 @@ def pystog_cli(kwargs=None):
     # Apply final scale number
     stog._add_keen_fq(q, sq)
     stog._add_keen_gr(r, gr_out)
-
-    if "PlotFlag" in kwargs:
-        if kwargs["PlotFlag"]:
-            stog.plot_summary_sq()
-            stog.plot_summary_gr()
-
-
-def transformer_cli():
-    # -------------------------------------#
-    # Converter / Transform Factory
-    tf = Transformer()
-    transform_functions = inspect.getmembers(tf, predicate=inspect.ismethod)
-    transform_dict = {entry[0]: entry[1] for entry in transform_functions}
-    transform_dict.pop('fourier_transform')
-    transform_dict.pop('_extend_axis_to_low_end')
-    transform_dict.pop('_low_x_correction')
-    transform_dict.pop('__init__')
-
-    cv = Converter()
-    converter_functions = inspect.getmembers(cv, predicate=inspect.ismethod)
-    converter_dict = {entry[0]: entry[1] for entry in converter_functions}
-    converter_dict.pop('__init__')
-
-    choices = transform_dict.copy()
-    choices.update(converter_dict)
-
-    def TransformationFactory(transform_name):
-        if transform_name in transform_dict:
-            return transform_dict[transform_name]
-        elif transform_name in converter_dict:
-            return converter_dict[transform_name]
-
-    # -------------------------------------#
-    # Main function CLI
-
-        parser = argparse.ArgumentParser()
-        parser.add_argument(
-            'transformation',
-            choices=choices.keys(),
-            help="Fourier transform G(r) -> S(Q)")
-        parser.add_argument(
-            '-x',
-            '--domain_range',
-            nargs=3,
-            default=(0.0, 100.0, 0.05),
-            type=float,
-            help="The domain (xmin, xmax, binsize) for transformed function")
-        parser.add_argument('-i', '--input', type=str, help='Input Filename')
-        parser.add_argument('-o', '--output', type=str, help='Output Filename')
-        parser.add_argument(
-            '-s',
-            '--skiprows',
-            type=int,
-            default=2,
-            help='Number of rows to skip in datasets')
-        parser.add_argument(
-            '-t',
-            '--trim',
-            type=int,
-            default=0,
-            help='Number of rows to trim off end in datasets')
-        parser.add_argument(
-            '--xcol', type=int, default=0, help='Set x-col for filename')
-        parser.add_argument(
-            '--ycol', type=int, default=1, help='Set y-col for filename')
-        parser.add_argument(
-            '--bcoh-sqrd',
-            type=float,
-            default=None,
-            dest='bcoh_sqrd',
-            help='Squared mean coherent scattering length (units=fm^2)')
-        parser.add_argument(
-            '--btot-sqrd',
-            type=float,
-            default=None,
-            dest='btot_sqrd',
-            help='Mean squared total scattering length (units=fm^2)')
-        parser.add_argument(
-            '--rho',
-            type=float,
-            default=None,
-            dest='rho',
-            help='Number density (units=atoms/angstroms^3)')
-        parser.add_argument(
-            '--plot',
-            action='store_true',
-            help='Show plot of before and after transformation')
-        parser.add_argument(
-            '--lorch',
-            action='store_true',
-            default=False,
-            help='Apply Lorch Modifcation')
-
-        args = parser.parse_args()
-
-        # Read in data
-        data = get_data(
-            args.input,
-            skiprows=args.skiprows,
-            skipfooter=args.trim,
-            xcol=args.xcol,
-            ycol=args.ycol)
-        # Setup domain
-        xmin, xmax, binsize = args.domain_range
-        xnew = create_domain(xmin, xmax, binsize)
-
-        # Add extra  key-word arguments needed for some conversions
-        kwargs = dict()
-        if args.bcoh_sqrd:
-            kwargs['<b_coh>^2'] = args.bcoh_sqrd
-        if args.rho:
-            kwargs['rho'] = args.rho
-        if args.btot_sqrd:
-            kwargs['<b_tot^2>'] = args.btot_sqrd
-        kwargs['lorch'] = args.lorch
-
-        # Transform data to new form
-        tf = TransformationFactory(args.transformation)
-        if args.transformation in transform_dict:
-            xnew, ynew = tf(data['x'].values, data['y'].values, xnew, **kwargs)
-        elif args.transformation in converter_dict:
-            xnew = data['x'].values
-            ynew = tf(data['x'].values, data['y'].values, **kwargs)
-
-        # Output file
-        write_out(args.output, xnew, ynew, title=args.transformation)
-
-        # Plot old and new data
-        if args.plot:
-            import matplotlib.pyplot as plt
-            plt.plot(data['x'].values, data['y'].values)
-            plt.plot(xnew, ynew)
-            plt.show()

--- a/pystog/converter.py
+++ b/pystog/converter.py
@@ -7,7 +7,6 @@ This module defines the Converter class
 that converts functions in the same space
 """
 
-from __future__ import (absolute_import, division, print_function)
 import numpy as np
 
 

--- a/pystog/fourier_filter.py
+++ b/pystog/fourier_filter.py
@@ -8,9 +8,6 @@ that performs the Fourier filter for a
 given range to exclude.
 """
 
-
-from __future__ import (absolute_import, division, print_function)
-
 import numpy as np
 
 from pystog.converter import Converter

--- a/pystog/io.py
+++ b/pystog/io.py
@@ -59,8 +59,6 @@ def get_cli_args():
         default=1.0,
         dest="btot_sqrd",
         help="The (sum c*b^2) term needed for DCS(Q) input")
-    parser.add_argument("--plot", action="store_true", default=False,
-                        help="Plots using matplotlib along the way")
     parser.add_argument("--merging", nargs=2, type=float, default=[0.0, 1.0],
                         help="Offset and Scale to apply to the merged S(Q)")
     parser.add_argument("--low-q-correction", action='store_true',
@@ -90,7 +88,6 @@ def parse_cli_args(args):
         "FourierFilter": {
             "Cutoff": args.fourier_filter_cutoff},
         "LorchFlag": args.lorch_flag,
-        "PlotFlag": args.plot,
         "Outputs": {
             "StemName": args.stem_name},
         "Merging": {

--- a/pystog/stog.py
+++ b/pystog/stog.py
@@ -791,7 +791,6 @@ class StoG(object):
         assert len(self.files) != 0
 
         for i, file_info in enumerate(self.files):
-            file_info['index'] = i
             self.read_dataset(file_info, **kwargs)
 
     def read_dataset(
@@ -830,12 +829,11 @@ class StoG(object):
         else:
             data = np.stack((_data[xcol], _data[ycol], _data[dycol]))
         info['data'] = data
-        self.add_dataset(info, index=info['index'], **kwargs)
+        self.add_dataset(info, **kwargs)
 
     def add_dataset(
             self,
             info,
-            index=0,
             yscale=1.,
             yoffset=0.,
             xoffset=0.,
@@ -848,8 +846,6 @@ class StoG(object):
         :param info: Dict with information for dataset
                      (filename, manipulations, etc.)
         :type info: dict
-        :param index: Index of the added reciprocal space function dataset
-        :type index: int
         :param yscale: Scale factor for the Y data
                        (i.e. :math:`S(Q)`, :math:`F(Q)`, etc.)
         :type yscale: float

--- a/pystog/stog.py
+++ b/pystog/stog.py
@@ -816,7 +816,8 @@ class StoG(object):
         if _data.shape[0] <= xcol or _data.shape[0] <= ycol:
             raise RuntimeError("Data format incompatible with input parameters")
         if _data.shape[0] <= dycol:
-            data = np.stack((_data[xcol], _data[ycol], np.zeros_like(_data[ycol])))
+            array_seq = (_data[xcol], _data[ycol], np.zeros_like(_data[ycol]))
+            data = np.stack(array_seq)
         else:
             data = np.stack((_data[xcol], _data[ycol], _data[dycol]))
         info['data'] = data
@@ -910,7 +911,8 @@ class StoG(object):
             raise ValueError(error)
 
         # Save reciprocal space function to the "invididuals" DataFrame
-        self.df_individuals = np.concatenate((self.df_individuals, np.stack((x, y, dy))), axis=1)
+        array_seq = (self.df_individuals, np.stack((x, y, dy)))
+        self.df_individuals = np.concatenate(array_seq, axis=1)
 
         # Convert to S(Q) and save to the individual S(Q) DataFrame
         if info["ReciprocalFunction"] == "Q[S(Q)-1]":
@@ -1057,10 +1059,11 @@ class StoG(object):
         sq = data_merged[1]
         dsq = data_merged[2]
 
-        q, sq, dsq = self._apply_scales_and_offset(q, sq,
-                                                   yscale=self.merged_opts['Y']['Scale'],
-                                                   yoffset=self.merged_opts['Y']['Offset'],
-                                                   xoffset=0.0, dy=dsq)
+        q, sq, dsq = self._apply_scales_and_offset(
+            q, sq,
+            yscale=self.merged_opts['Y']['Scale'],
+            yoffset=self.merged_opts['Y']['Offset'],
+            xoffset=0.0, dy=dsq)
         self.df_q_master[self.sq_title] = q
         self.df_sq_master[self.sq_title] = sq
 

--- a/pystog/transformer.py
+++ b/pystog/transformer.py
@@ -7,7 +7,6 @@ This module defines the Transformer class
 that performs the Fourier transforms
 """
 
-from __future__ import (absolute_import, division, print_function)
 import numpy as np
 
 from pystog.converter import Converter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 matplotlib==3.3.3
 numpy==1.19.4
-pandas>=1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-matplotlib==3.3.3
 numpy==1.19.4

--- a/tests/extra/nickel_pdffit_tester.py
+++ b/tests/extra/nickel_pdffit_tester.py
@@ -104,7 +104,6 @@ class nickel(object):
 
 
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
     ni = nickel()
     print("Distances for r_ij: ", ni.get_distances())
     print("Sigmas for sig_ij:", ni.get_sigmas())
@@ -119,5 +118,3 @@ if __name__ == "__main__":
     rho = ni.get_density()
 
     G = GofR(r, rij, sig_ij, Np, cij, bij, bavg, rho=rho)
-    plt.plot(r, G)
-    plt.show()

--- a/tests/test_stog.py
+++ b/tests/test_stog.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 from numpy.testing import assert_allclose
 
 import os
@@ -358,29 +357,27 @@ class TestStogAttributes(TestStogBase):
 class TestStogDataFrameAttributes(TestStogBase):
     def setUp(self):
         super(TestStogDataFrameAttributes, self).setUp()
-        self.df_target = pd.DataFrame(np.random.randn(10, 2),
-                                      index=np.arange(10),
-                                      columns=list('XY'))
+        self.df_target = np.random.randn(3, 10)
 
     def test_stog_df_individuals_setter(self):
         stog = StoG()
         stog.df_individuals = self.df_target
-        self.assertTrue(stog.df_individuals.equals(self.df_target))
+        assert_allclose(stog.df_individuals, self.df_target)
 
     def test_stog_df_sq_individuals_setter(self):
         stog = StoG()
         stog.df_sq_individuals = self.df_target
-        self.assertTrue(stog.df_sq_individuals.equals(self.df_target))
+        assert_allclose(stog.df_sq_individuals, self.df_target)
 
     def test_stog_df_sq_master_setter(self):
         stog = StoG()
         stog.df_sq_master = self.df_target
-        self.assertTrue(stog.df_sq_master.equals(self.df_target))
+        assert_allclose(stog.df_sq_master, self.df_target)
 
     def test_stog_df_gr_master_setter(self):
         stog = StoG()
         stog.df_gr_master = self.df_target
-        self.assertTrue(stog.df_gr_master.equals(self.df_target))
+        assert_allclose(stog.df_gr_master, self.df_target)
 
 
 class TestStogGeneralMethods(TestStogBase):
@@ -1047,12 +1044,11 @@ class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
                 # Using stem name
                 write_out_func()
 
-                data = pd.read_csv(filename,
-                                   sep=r"\s+",
-                                   usecols=[0, 1],
-                                   names=['x', 'y'],
-                                   skiprows=2,
-                                   engine='python')
+                data = {}
+                data['x'], data['y'] = np.genfromtxt(
+                    filename,
+                    skip_header=2,
+                    unpack=True)
 
                 assert_allclose(data['x'], x)
                 assert_allclose(
@@ -1070,12 +1066,10 @@ class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
 
                 write_out_func(filename=tmp_filename)
 
-                data = pd.read_csv(tmp_filename,
-                                   sep=r"\s+",
-                                   usecols=[0, 1],
-                                   names=['x', 'y'],
-                                   skiprows=2,
-                                   engine='python')
+                data['x'], data['y'] = np.genfromtxt(
+                    tmp_filename,
+                    skip_header=2,
+                    unpack=True)
 
                 assert_allclose(data['x'], x)
                 assert_allclose(data['y'], y)
@@ -1090,12 +1084,11 @@ class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
         x = self.stog.df_q_master[self.stog.sq_title]
         y = self.stog.df_sq_master[self.stog.sq_title]
         self.stog._write_out_to_file(x, y, outfile_path)
-        data = pd.read_csv(outfile_path,
-                           sep=r"\s+",
-                           usecols=[0, 1],
-                           names=['x', 'y'],
-                           skiprows=2,
-                           engine='python')
+        data = {}
+        data['x'], data['y'] = np.genfromtxt(
+            outfile_path,
+            skip_header=2,
+            unpack=True)
 
         q = self.stog.df_q_master[self.stog.sq_title]
         sq = self.stog.df_sq_master[self.stog.sq_title]

--- a/tests/test_stog.py
+++ b/tests/test_stog.py
@@ -3,7 +3,6 @@ import pandas as pd
 from numpy.testing import assert_allclose
 
 import os
-import sys
 from tests.utils import \
     get_data_path, load_data, get_index_of_function
 from tests.materials import Argon
@@ -13,13 +12,6 @@ from pystog.stog import StoG
 
 import tempfile
 import unittest
-if sys.version_info >= (3, 3):
-    from unittest.mock import patch
-else:
-    from mock import patch
-
-
-# Real Space Function
 
 
 class TestStogBase(unittest.TestCase):
@@ -805,11 +797,11 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
 
         # Check g(r) data against targets
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first].name,
+            stog.df_r_master[stog.gr_ft_title][self.real_space_first],
             self.real_xtarget,
             places=places)
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_ft_title],
+            stog.df_gr_master[stog.gr_ft_title][self.real_space_first],
             self.gofr_ff_target[0],
             places=places)
 
@@ -827,11 +819,11 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
 
         # Check g(r) data against targets
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first].name,
+            stog.df_r_master[stog.gr_ft_title][self.real_space_first],
             self.real_xtarget,
             places=places)
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_ft_title],
+            stog.df_gr_master[stog.gr_ft_title][self.real_space_first],
             self.gofr_ff_target[0],
             places=places)
 
@@ -851,11 +843,11 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
 
         # Check g(r) data against targets
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first].name,
+            stog.df_r_master[stog.gr_ft_title][self.real_space_first],
             self.real_xtarget,
             places=places)
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_ft_title],
+            stog.df_gr_master[stog.gr_ft_title][self.real_space_first],
             self.GofR_ff_target[0],
             places=places)
 
@@ -875,25 +867,13 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
 
         # Check g(r) data against targets
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first].name,
+            stog.df_r_master[stog.gr_ft_title][self.real_space_first],
             self.real_xtarget,
             places=places)
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_ft_title],
+            stog.df_gr_master[stog.gr_ft_title][self.real_space_first],
             self.GKofR_ff_target[0],
             places=places)
-
-    @patch("matplotlib.pyplot.show")
-    def test_stog_fourier_filter_with_plot_flag(self, mock_show):
-        # Load S(Q) for Argon from test data
-        stog = StoG(**self.kwargs_for_stog_input)
-        stog.files = self.kwargs_for_files['Files']
-        stog.plot_flag = True
-        stog.read_all_data()
-        stog.merge_data()
-        stog.transform_merged()
-        stog.fourier_filter()
-        mock_show.assert_called_with()
 
     def test_stog_fourier_filter_for_nan_after_filter(self):
         # Load S(Q) for Argon from test data
@@ -906,13 +886,13 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
         stog.fourier_filter()
 
         self.assertFalse(
-            np.isnan(stog.df_gr_master[stog.gr_title].values).any())
+            np.isnan(stog.df_gr_master[stog.gr_title]).any())
         self.assertFalse(
-            np.isnan(stog.df_sq_master[stog.sq_title].values).any())
+            np.isnan(stog.df_sq_master[stog.sq_title]).any())
         self.assertFalse(
-            np.isnan(stog.df_sq_master[stog._ft_title].values).any())
+            np.isnan(stog.df_sq_master[stog._ft_title]).any())
         self.assertFalse(
-            np.isnan(stog.df_sq_master[stog.sq_ft_title].values).any())
+            np.isnan(stog.df_sq_master[stog.sq_ft_title]).any())
 
     def test_stog_apply_lorch_default(self):
         # Number of decimal places for precision
@@ -929,7 +909,7 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
         stog.apply_lorch(q, sq, r)
 
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_lorch_title],
+            stog.df_gr_master[stog.gr_lorch_title][self.real_space_first],
             self.gofr_lorch_target[0],
             places=places)
 
@@ -949,7 +929,7 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
         stog.apply_lorch(q, sq, r)
 
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_lorch_title],
+            stog.df_gr_master[stog.gr_lorch_title][self.real_space_first],
             self.GofR_lorch_target[0],
             places=places)
 
@@ -969,21 +949,8 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
         stog.apply_lorch(q, sq, r)
 
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_lorch_title],
+            stog.df_gr_master[stog.gr_lorch_title][self.real_space_first],
             self.GKofR_lorch_target[0], places=places)
-
-    @patch("matplotlib.pyplot.show")
-    def test_stog_apply_lorch_with_plot_flag(self, mock_show):
-        # Load S(Q) for Argon from test data
-        stog = StoG(**self.kwargs_for_stog_input)
-        stog.files = self.kwargs_for_files['Files']
-        stog.plot_flag = True
-        stog.read_all_data()
-        stog.merge_data()
-        stog.transform_merged()
-        q, sq, r, gr = stog.fourier_filter()
-        stog.apply_lorch(q, sq, r)
-        mock_show.assert_called_with()
 
     def test_stog_lowR_mean_square(self):
         # Load S(Q) for Argon from test data
@@ -1023,17 +990,17 @@ class TestStogPlottingDataFrameMethods(TestStogDatasetSpecificMethods):
 
     def test_stog_add_keen_fq(self):
         stog = self.stog
-        q = stog.df_sq_master[stog.sq_title].index.values
-        sq = stog.df_sq_master[stog.sq_title].values
+        q = stog.df_sq_master[stog.sq_title]
+        sq = stog.df_sq_master[stog.sq_title]
         stog._add_keen_fq(q, sq)
-        self.assertTrue(stog.fq_title in stog.df_sq_master.columns)
+        self.assertTrue(stog.fq_title in stog.df_sq_master)
 
     def test_stog_add_keen_gr_default(self):
         stog = self.stog
-        r = stog.df_gr_master[stog.gr_title].index.values
-        gr = stog.df_gr_master[stog.gr_title].values
+        r = stog.df_gr_master[stog.gr_title]
+        gr = stog.df_gr_master[stog.gr_title]
         stog._add_keen_gr(r, gr)
-        self.assertTrue(stog.GKofR_title in stog.df_gr_master.columns)
+        self.assertTrue(stog.GKofR_title in stog.df_gr_master)
 
     def test_stog_add_keen_gr_GofR(self):
         stog = StoG(**self.kwargs_for_stog_input)
@@ -1042,10 +1009,10 @@ class TestStogPlottingDataFrameMethods(TestStogDatasetSpecificMethods):
         stog.read_all_data()
         stog.merge_data()
         stog.transform_merged()
-        r = stog.df_gr_master[stog.gr_title].index.values
-        gr = stog.df_gr_master[stog.gr_title].values
+        r = stog.df_gr_master[stog.gr_title]
+        gr = stog.df_gr_master[stog.gr_title]
         stog._add_keen_gr(r, gr)
-        self.assertTrue(stog.GKofR_title in stog.df_gr_master.columns)
+        self.assertTrue(stog.GKofR_title in stog.df_gr_master)
 
     def test_stog_add_keen_gr_GKofR(self):
         stog = StoG(**self.kwargs_for_stog_input)
@@ -1054,10 +1021,11 @@ class TestStogPlottingDataFrameMethods(TestStogDatasetSpecificMethods):
         stog.read_all_data()
         stog.merge_data()
         stog.transform_merged()
-        r = stog.df_gr_master[stog.gr_title].index.values
-        gr = stog.df_gr_master[stog.gr_title].values
+        r = stog.df_gr_master[stog.gr_title]
+        gr = stog.df_gr_master[stog.gr_title]
         stog._add_keen_gr(r, gr)
-        self.assertTrue(stog.GKofR_title in stog.df_gr_master.columns)
+        self.assertTrue(stog.GKofR_title in stog.df_gr_master)
+
 
 class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
     def setUp(self):
@@ -1073,16 +1041,13 @@ class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
         self.stog = stog
 
     # Decorator to provide the data to run each write_out_<type> test
-    def data_provider(self, stog, df, title, filename):
+    def data_provider(self, x, y, filename):
         def write_out_decorator(write_out_func):
             def wrap_function(*args):
                 # Using stem name
                 write_out_func()
-                x = df[title].index.values
-                y = df[title].values
 
-                outfile_path = filename
-                data = pd.read_csv(outfile_path,
+                data = pd.read_csv(filename,
                                    sep=r"\s+",
                                    usecols=[0, 1],
                                    names=['x', 'y'],
@@ -1098,16 +1063,14 @@ class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
                     atol=2.0,
                     equal_nan=True)
 
-                os.remove(outfile_path)
+                os.remove(filename)
 
                 # Using set filename
-                outfile_path = tempfile.mkstemp()[1]
+                tmp_filename = tempfile.mkstemp()[1]
 
-                write_out_func(filename=outfile_path)
-                x = df[title].index.values
-                y = df[title].values
+                write_out_func(filename=tmp_filename)
 
-                data = pd.read_csv(outfile_path,
+                data = pd.read_csv(tmp_filename,
                                    sep=r"\s+",
                                    usecols=[0, 1],
                                    names=['x', 'y'],
@@ -1116,30 +1079,17 @@ class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
 
                 assert_allclose(data['x'], x)
                 assert_allclose(data['y'], y)
-                os.remove(outfile_path)
+                os.remove(tmp_filename)
 
             return wrap_function
         return write_out_decorator
 
     # Tests
-    def test_stog_add_to_dataframe(self):
-        x = np.random.randn(10)
-        y1 = np.random.randn(10)
-        y2 = np.random.randn(10)
-        df_target = pd.DataFrame(np.column_stack(
-            [y1, y2]), columns=['y1', 'y2'], index=x)
-        df = pd.DataFrame(np.column_stack([y1]), columns=['y1'], index=x)
-        df = self.stog.add_to_dataframe(x, y2, df, 'y2')
-        self.assertTrue(df.equals(df_target))
-
-        y3 = np.random.randn(10)
-        df = self.stog.add_to_dataframe(x, y3, df, 'y2')
-        self.assertFalse(df.equals(df_target))
-
     def test_stog_write_df(self):
         outfile_path = tempfile.mkstemp()[1]
-        self.stog._write_out_df(self.stog.df_sq_master,
-                                [self.stog.sq_title], outfile_path)
+        x = self.stog.df_q_master[self.stog.sq_title]
+        y = self.stog.df_sq_master[self.stog.sq_title]
+        self.stog._write_out_to_file(x, y, outfile_path)
         data = pd.read_csv(outfile_path,
                            sep=r"\s+",
                            usecols=[0, 1],
@@ -1147,23 +1097,19 @@ class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
                            skiprows=2,
                            engine='python')
 
-        q = self.stog.df_sq_master[self.stog.sq_title].index.values
-        sq = self.stog.df_sq_master[self.stog.sq_title].values
+        q = self.stog.df_q_master[self.stog.sq_title]
+        sq = self.stog.df_sq_master[self.stog.sq_title]
 
         assert_allclose(data['x'], q)
         assert_allclose(data['y'], sq)
         os.remove(outfile_path)
 
-        with self.assertRaises(ValueError):
-            self.stog._write_out_df(pd.DataFrame(), 'title', outfile_path)
-
     def test_write_out_merged_sq(self):
         # Have to decorate after the setUp() is called for the self.* args to
         # work
         @self.data_provider(
-            self.stog,
-            self.stog.df_sq_master,
-            self.stog.sq_title,
+            self.stog.df_q_master[self.stog.sq_title],
+            self.stog.df_sq_master[self.stog.sq_title],
             "dog.sq")
         def decorated_write_out_merged(*args, **kwargs):
             self.stog.write_out_merged_sq(*args, **kwargs)
@@ -1173,9 +1119,8 @@ class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
         # Have to decorate after the setUp() is called for the self.* args to
         # work
         @self.data_provider(
-            self.stog,
-            self.stog.df_gr_master,
-            self.stog.gr_title,
+            self.stog.df_r_master[self.stog.gr_title],
+            self.stog.df_gr_master[self.stog.gr_title],
             "dog.gr")
         def decorated_write_out_merged(*args, **kwargs):
             self.stog.write_out_merged_gr(*args, **kwargs)
@@ -1187,9 +1132,8 @@ class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
         # work
 
         @self.data_provider(
-            self.stog,
-            self.stog.df_sq_master,
-            self.stog.sq_ft_title,
+            self.stog.df_q_master[self.stog.sq_ft_title],
+            self.stog.df_sq_master[self.stog.sq_ft_title],
             'dog_ft.sq')
         def decorated_write_out_merged(*args, **kwargs):
             self.stog.write_out_ft_sq(*args, **kwargs)

--- a/tests/test_stog.py
+++ b/tests/test_stog.py
@@ -490,69 +490,71 @@ class TestStogDatasetSpecificMethods(TestStogBase):
         # Scale S(Q) and make sure it does not equal original target values
         stog = StoG()
         info = {
-            'data': pd.DataFrame({'x': self.q, 'y': self.sq}),
+            'data': [self.q, self.sq],
             'ReciprocalFunction': 'S(Q)',
             'Y': {'Scale': 2.0}}
         stog.add_dataset(info)
         self.assertNotEqual(
-            stog.df_individuals.iloc[self.first]['S(Q)_%d' % index],
+            stog.df_individuals[1][self.first],
             self.sq_target[0])
         self.assertNotEqual(
-            stog.df_sq_individuals.iloc[self.first]['S(Q)_%d' % index],
+            stog.df_sq_individuals[1][self.first],
             self.sq_target[0])
 
     def test_stog_add_dataset_yoffset(self):
         # Offset S(Q) and make sure it does not equal original target values
         stog = StoG()
         info = {
-            'data': pd.DataFrame({'x': self.q, 'y': self.sq}),
+            'data': [self.q, self.sq],
             'ReciprocalFunction': 'S(Q)',
             'Y': {'Offset': 2.0}}
         stog.add_dataset(info)
         self.assertNotEqual(
-            stog.df_individuals.iloc[self.first]['S(Q)_%d' % index],
+            stog.df_individuals[1][self.first],
             self.sq_target[0])
         self.assertNotEqual(
-            stog.df_sq_individuals.iloc[self.first]['S(Q)_%d' % index],
+            stog.df_sq_individuals[1][self.first],
             self.sq_target[0])
 
     def test_stog_add_dataset_xoffset(self):
         # Offset Q from 1.96 -> 2.14
         stog = StoG()
         info = {
-            'data': pd.DataFrame({'x': self.q, 'y': self.sq}),
+            'data': [self.q, self.sq],
             'ReciprocalFunction': 'S(Q)',
             'X': {'Offset': 0.2}}
         stog.add_dataset(info)
-        self.assertEqual(stog.df_individuals.iloc[self.first].name, 2.14)
+        self.assertEqual(stog.df_individuals[0][self.first], 2.14)
 
     def test_stog_add_dataset_qmin_qmax_crop(self):
         # Check qmin and qmax apply cropping
         stog = StoG()
-        info = {'data': pd.DataFrame({'x': self.q, 'y': self.sq}),
+        info = {'data': [self.q, self.sq],
                 'ReciprocalFunction': 'S(Q)'}
         stog.qmin = 1.5
         stog.qmax = 12.0
         stog.add_dataset(info)
-        self.assertEqual(stog.df_individuals.iloc[0].name, stog.qmin)
-        self.assertEqual(stog.df_individuals.iloc[-1].name, stog.qmax)
+        self.assertEqual(stog.df_individuals[0][0], stog.qmin)
+        self.assertEqual(stog.df_individuals[0][-1], stog.qmax)
 
     def test_stog_add_dataset_default_reciprocal_space_function(self):
-        # Checks the default reciprocal space function is S(Q) and the index is
-        # set
+        # Checks the default reciprocal space function is S(Q)
+        places = 5
         stog = StoG()
-        info = {'data': pd.DataFrame({'x': self.q, 'y': self.sq})}
+        info = {'data': [self.q, self.sq]}
         stog.add_dataset(info)
         self.assertEqual(
-            list(
-                stog.df_individuals.columns.values), [
-                'S(Q)_%d' %
-                index])
+            stog.df_individuals[0][self.first],
+            self.reciprocal_xtarget)
+        self.assertAlmostEqual(
+            stog.df_individuals[1][self.first],
+            self.sq_target[0],
+            places=places)
 
     def test_stog_add_dataset_wrong_reciprocal_space_function_exception(self):
         # Check qmin and qmax apply cropping
         stog = StoG()
-        info = {'data': pd.DataFrame({'x': self.q, 'y': self.sq}),
+        info = {'data': [self.q, self.sq],
                 'ReciprocalFunction': 'ABCDEFG(Q)'}
         with self.assertRaises(ValueError):
             stog.add_dataset(info)
@@ -645,7 +647,6 @@ class TestStogDatasetSpecificMethods(TestStogBase):
         stog.merge_data()
 
         # Check S(Q) data against targets
-        self.assertEqual(0, 1)
         self.assertEqual(
             stog.df_q_master[stog.sq_title][self.first],
             self.reciprocal_xtarget)

--- a/tests/test_stog.py
+++ b/tests/test_stog.py
@@ -587,13 +587,14 @@ class TestStogDatasetSpecificMethods(TestStogBase):
 
         # Check S(Q) data against targets
         self.assertEqual(
-            stog.df_individuals.iloc[self.first].name, self.reciprocal_xtarget)
+            stog.df_individuals[0][self.first],
+            self.reciprocal_xtarget)
         self.assertAlmostEqual(
-            stog.df_individuals.iloc[self.first]['S(Q)_%d' % info['index']],
+            stog.df_individuals[1][self.first],
             self.sq_target[0],
             places=places)
         self.assertAlmostEqual(
-            stog.df_sq_individuals.iloc[self.first]['S(Q)_%d' % info['index']],
+            stog.df_sq_individuals[1][self.first],
             self.sq_target[0],
             places=places)
 
@@ -628,14 +629,14 @@ class TestStogDatasetSpecificMethods(TestStogBase):
 
         # Check S(Q) data against targets
         self.assertEqual(
-            stog.df_individuals.iloc[self.first].name, self.reciprocal_xtarget)
+            stog.df_individuals[0][self.first], self.reciprocal_xtarget)
         for index in range(len(stog.files)):
             self.assertAlmostEqual(
-                stog.df_individuals.iloc[self.first]['S(Q)_%d' % index],
+                stog.df_individuals[1][self.first],
                 self.sq_target[0],
                 places=places)
             self.assertAlmostEqual(
-                stog.df_sq_individuals.iloc[self.first]['S(Q)_%d' % index],
+                stog.df_sq_individuals[1][self.first],
                 self.sq_target[0],
                 places=places)
 
@@ -651,9 +652,10 @@ class TestStogDatasetSpecificMethods(TestStogBase):
 
         # Check S(Q) data against targets
         self.assertEqual(
-            stog.df_sq_master.iloc[self.first].name, self.reciprocal_xtarget)
+            stog.df_q_master[stog.sq_title][self.first],
+            self.reciprocal_xtarget)
         self.assertAlmostEqual(
-            stog.df_sq_master.iloc[self.first][stog.sq_title],
+            stog.df_sq_master[stog.sq_title][self.first],
             self.sq_target[0],
             places=places)
 
@@ -671,7 +673,7 @@ class TestStogDatasetSpecificMethods(TestStogBase):
         stog.merged_opts['Q[S(Q)-1]'] = qsq_opts
         stog.merge_data()
         self.assertAlmostEqual(
-            stog.df_sq_master.iloc[self.first][stog.qsq_minus_one_title],
+            stog.df_sq_master[stog.qsq_minus_one_title][self.first],
             qsq_opts['Y']['Scale'] * self.fq_target[0],
             places=places)
 
@@ -689,7 +691,7 @@ class TestStogDatasetSpecificMethods(TestStogBase):
         stog.merged_opts['Q[S(Q)-1]'] = qsq_opts
         stog.merge_data()
         self.assertAlmostEqual(
-            stog.df_sq_master.iloc[self.first][stog.qsq_minus_one_title],
+            stog.df_sq_master[stog.qsq_minus_one_title][self.first],
             qsq_opts['Y']['Offset'] + self.fq_target[0],
             places=places)
 
@@ -712,11 +714,11 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
 
         # Check g(r) data against targets
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first].name,
+            stog.df_r_master[stog.gr_title][self.real_space_first],
             self.real_xtarget,
             places=places)
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_title],
+            stog.df_gr_master[stog.gr_title][self.real_space_first],
             self.gofr_target[0],
             places=places)
 
@@ -726,11 +728,11 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
 
         # Check g(r) data against targets
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first].name,
+            stog.df_r_master[stog.gr_title][self.real_space_first],
             self.real_xtarget,
             places=places)
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_title],
+            stog.df_gr_master[stog.gr_title][self.real_space_first],
             self.gofr_target[0],
             places=places)
 
@@ -748,11 +750,11 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
 
         # Check G(r) data against targets
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first].name,
+            stog.df_r_master[stog.gr_title][self.real_space_first],
             self.real_xtarget,
             places=places)
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_title],
+            stog.df_gr_master[stog.gr_title][self.real_space_first],
             self.GofR_target[0],
             places=places)
 
@@ -770,11 +772,11 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
 
         # Check GK(r) data against targets
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first].name,
+            stog.df_r_master[stog.gr_title][self.real_space_first],
             self.real_xtarget,
             places=places)
         self.assertAlmostEqual(
-            stog.df_gr_master.iloc[self.real_space_first][stog.gr_title],
+            stog.df_gr_master[stog.gr_title][self.real_space_first],
             self.GKofR_target[0],
             places=places)
 
@@ -788,9 +790,9 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
         stog.transform_merged()
 
         self.assertFalse(
-            np.isnan(stog.df_sq_master[stog.sq_title].values).any())
+            np.isnan(stog.df_sq_master[stog.sq_title]).any())
         self.assertFalse(
-            np.isnan(stog.df_gr_master[stog.gr_title].values).any())
+            np.isnan(stog.df_gr_master[stog.gr_title]).any())
 
     def test_stog_fourier_filter(self):
         # Number of decimal places for precision
@@ -995,7 +997,7 @@ class TestStogTransformSpecificMethods(TestStogDatasetSpecificMethods):
         stog.read_all_data()
         stog.merge_data()
         stog.transform_merged()
-        gr = stog.df_gr_master[stog.gr_title].values
+        gr = stog.df_gr_master[stog.gr_title]
         cost = stog._lowR_mean_square(stog.dr, gr)
         self.assertAlmostEqual(cost, self.lowR_target, places=7)
 
@@ -1060,45 +1062,6 @@ class TestStogPlottingDataFrameMethods(TestStogDatasetSpecificMethods):
         gr = stog.df_gr_master[stog.gr_title].values
         stog._add_keen_gr(r, gr)
         self.assertTrue(stog.GKofR_title in stog.df_gr_master.columns)
-
-    @patch("matplotlib.pyplot.show")
-    def test_stog_plot_df(self, mock_show):
-        df = pd.DataFrame(np.random.randn(10, 2),
-                          index=np.arange(10),
-                          columns=list('XY'))
-        stog = StoG()
-        stog._plot_df(df, 'x', 'y', 'title', None)
-        mock_show.assert_called_with()
-
-    @patch("matplotlib.pyplot.show")
-    def test_stog_plot_sq(self, mock_show):
-        self.stog.plot_sq()
-        mock_show.assert_called_with()
-
-    @patch("matplotlib.pyplot.show")
-    def test_stog_plot_merged_sq(self, mock_show):
-        self.stog.plot_merged_sq()
-        mock_show.assert_called_with()
-
-        self.stog.df_individuals = pd.DataFrame()
-        self.stog.plot_merged_sq()
-        mock_show.assert_called_with()
-
-    @patch("matplotlib.pyplot.show")
-    def test_stog_plot_gr(self, mock_show):
-        self.stog.plot_gr()
-        mock_show.assert_called_with()
-
-    @patch("matplotlib.pyplot.show")
-    def test_stog_plot_summary_sq(self, mock_show):
-        self.stog.plot_summary_sq()
-        mock_show.assert_called_with()
-
-    @patch("matplotlib.pyplot.show")
-    def test_stog_plot_summary_gr(self, mock_show):
-        self.stog.plot_summary_gr()
-        mock_show.assert_called_with()
-
 
 class TestStogOutputDataFrameMethods(TestStogDatasetSpecificMethods):
     def setUp(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import numpy as np
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,9 @@ commands =
 [testenv:lint]
 deps = flake8
 commands =
-    flake8 --ignore=E402 --max-line-length=100 pystog/
-    flake8 --ignore=E402 --max-line-length=100 tests/
-    flake8 --ignore=E402 --max-line-length=100 setup.py
+    flake8 pystog/
+    flake8 tests/
+    flake8 setup.py
 
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ python =
 deps = -rrequirements.txt
        -rrequirements-dev.txt
 commands = 
-    pytest
+    pytest {posargs}
 
 [testenv:lint]
 deps = flake8

--- a/tutorials/example01_using_converter.ipynb
+++ b/tutorials/example01_using_converter.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Notebook prerequisites \n",
+    "NOTICE: These are prerequisite steps to run the examples on Binder. Locally, you probably do not have to execute the cell below\n",
+    "\n",
+    "This is to install PyStoG into the environment and then matplotlib for visualization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!type python\n",
+    "!python -m pip install ../\n",
+    "!python -m pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# How to use the Converter class from PyStoG\n",
     "\n",
     "This tutorial shows how to use the `Converter` class from `pystog`"
@@ -285,13 +308,6 @@
     "ax[1, 1].set_xlabel(xlabel)\n",
     "plt.show()\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -310,7 +326,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.12"
   }
  },
  "nbformat": 4,

--- a/tutorials/example02_using_transformer.ipynb
+++ b/tutorials/example02_using_transformer.ipynb
@@ -4,6 +4,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Notebook prerequisites\n",
+    "\n",
+    "NOTICE: These are prerequisite steps to run the examples on Binder. Locally, you probably do not have to execute the cell below\n",
+    "\n",
+    "This is to install PyStoG into the environment and then matplotlib for visualization.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!type python\n",
+    "!python -m pip install ../\n",
+    "!python -m pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# How to use the Transformer class from PyStoG\n",
     "\n",
     "This tutorial shows how to use the `Transformer` class from `pystog`\n"
@@ -46,7 +68,7 @@
     "import pystog\n",
     "data_file = os.path.join('..', 'tests', 'test_data', 'argon.gr')\n",
     "i, r, gr, nr = np.loadtxt(data_file, unpack=True, skiprows=5)\n",
-    "r"
+    "print(\"r vector: \", r)"
    ]
   },
   {
@@ -122,7 +144,7 @@
    "source": [
     "buffer = 0.001\n",
     "q = np.arange(0.12, 35. + buffer, 0.02)\n",
-    "q"
+    "print(\"Q vector: \", q)"
    ]
   },
   {
@@ -274,7 +296,7 @@
    "source": [
     "buffer = 0.001\n",
     "r = np.arange(0.075, 63.975 + buffer, 0.05)\n",
-    "r"
+    "print(\"r vector: \", r)"
    ]
   },
   {
@@ -316,13 +338,6 @@
     "ax[2].set_xlabel('r [$\\AA$]')\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -341,7 +356,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.12"
   }
  },
  "nbformat": 4,

--- a/tutorials/example04_using_stog.ipynb
+++ b/tutorials/example04_using_stog.ipynb
@@ -4,6 +4,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Notebook prerequisites\n",
+    "\n",
+    "NOTICE: These are prerequisite steps to run the examples on Binder. Locally, you probably do not have to execute the cell below\n",
+    "\n",
+    "This is to install PyStoG into the environment and then matplotlib for visualization.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!type python\n",
+    "!python -m pip install ../\n",
+    "!python -m pip install matplotlib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# How to use the StoG class from PyStoG\n",
     "\n",
     "This tutorial shows how to use the `StoG` class from `pystog`\n"
@@ -267,61 +289,6 @@
     "stog.transform_merged()\n",
     "stog.fourier_filter()"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Even though we have already processed the files, we can view the dianostics from the initial merge:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stog.plot_merged_sq()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can also view the processed $S(Q)$, the filter applied, and the resulting $Q[S(Q)-1]$"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stog.plot_sq()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And finally, we can see the resulting real space data for each step as well:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stog.plot_gr()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -340,7 +307,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Work includes:
 - Removing pandas dependency by using numpy arrays for storage (thanks to @mdoucet!)
 - Removing plotting capabilities and matplotlib dependency
 - Deprecates the Transformer CLI tool (not the Transformer module, though)
 - Small fixes to references of the repository before the migration to neutrons
 - Renaming of variables to remove the `df_` prefix since we not longer use pandas DataFrames.
 - Remove Python 2 support (via removing `__future__` imports and `six` dependency)
 - Added header section to notebooks to install local `pystog` and `matplotlib` via pip

Closes #37, #38, #39