### PR TITLE
Unpin requirements file for numpy + drop py39 from CI/CD

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8"]
         
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-numpy==1.19.4
+numpy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,lint,coverage
+envlist = py36,py37,py38,py39,lint,lint-security,coverage
 
 
 [gh-actions]


### PR DESCRIPTION
Pinning numpy is causing an error with the conda package for downstream dependencies (mainly, ADDIE)
Unpinning to allow it to be flexible for the version.

Also, dropping Python 3.9 due to an error in trying to upload to anaconda.
Will have to debug in a separate issue before we can add this back in.