### PR TITLE
Remove runtime dependency on python version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8"]
-        
+        python-version: ["3.10", "3.11"]
+
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
@@ -52,11 +52,11 @@ jobs:
           tox -e coverage
           pip install coverage
           bash <(curl -s https://codecov.io/bash)
-        
+
       - name: Build Python package and Upload to PyPi
         shell: bash -l {0}
         if: startsWith( github.ref, 'refs/tags/v') && matrix.python-version == env.PYTHON_MAIN_VERSION
-        env: 
+        env:
             PYPI_TOKEN_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           pip install wheel twine
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build conda package and upload to Anaconda
         shell: bash -l {0}
-        if: startsWith( github.ref, 'refs/tags/v')
+        if: startsWith( github.ref, 'refs/tags/v') && matrix.python-version == env.PYTHON_MAIN_VERSION
         env:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
           IS_RC: ${{ contains(github.ref, 'rc') }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,7 +9,6 @@ source:
 
 build:
   noarch: python
-  string: py{{py}}
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - pystog_cli = pystog.cli:pystog_cli


### PR DESCRIPTION
Currently the conda package sets a fixed python version based on what it was built with. This removes that dependency.

This also advances python versions used in the builds.

[Anaconda blog article about noarch](https://www.anaconda.com/blog/condas-new-noarch-packages). 

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
[EWM4729](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4729)
